### PR TITLE
Improve test coverage for api and public modules

### DIFF
--- a/dribdat/api/parser.py
+++ b/dribdat/api/parser.py
@@ -51,7 +51,7 @@ def get_gitlab_project(url, with_history):
     apiurl = url
     apiurl = re.sub(r"(?i)-?/blob/[a-z]+/README.*", "", apiurl)
     apiurl = re.sub(r"https?://gitlab\.com/", "", apiurl).strip("/")
-    if apiurl == url:
+    if apiurl == "" or apiurl == url:
         return {}
     return FetchGitlabProject(apiurl, with_history)
 
@@ -65,7 +65,7 @@ def get_github_project(url, with_history):
     apiurl = re.sub(r"https?://github\.com/", "", apiurl).strip("/")
     if apiurl.endswith(".git"):
         apiurl = apiurl[:-4]
-    if apiurl == url:
+    if apiurl == "" or apiurl == url:
         return {}
     if apiurl.endswith(".md"):
         # GitHub Markdown
@@ -83,7 +83,7 @@ def get_codeberg_project(url, with_history):
     apiurl = re.sub(r"https?://codeberg\.org/", "", apiurl).strip("/")
     if apiurl.endswith(".git"):
         apiurl = apiurl[:-4]
-    if apiurl == url:
+    if apiurl == "" or apiurl == url:
         return {}
     return FetchCodebergProject(apiurl, with_history)
 
@@ -91,7 +91,7 @@ def get_codeberg_project(url, with_history):
 def get_huggingface_project(url, with_history):
     """Prepare a HuggingFace URL for the API."""
     apiurl = re.sub(r"https?://huggingface\.co/", "", url).strip("/")
-    if apiurl == url:
+    if apiurl == "" or apiurl == url:
         return {}
     return FetchHuggingFaceProject(apiurl, with_history)
 

--- a/dribdat/public/auth.py
+++ b/dribdat/public/auth.py
@@ -67,7 +67,7 @@ def load_user(user_id):
 
 def oauth_type():
     """Check if Slack or another OAuth has been configured."""
-    if "OAUTH_TYPE" in current_app.config:
+    if "OAUTH_TYPE" in current_app.config and current_app.config["OAUTH_TYPE"]:
         return current_app.config["OAUTH_TYPE"].lower()
     else:
         return None

--- a/tests/test_api_parser.py
+++ b/tests/test_api_parser.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import patch, MagicMock
+from dribdat.api.parser import (
+    GetProjectData,
+    get_gitlab_project,
+    get_github_project,
+    get_codeberg_project,
+    get_huggingface_project
+)
+
+class TestApiParser:
+
+    @patch('dribdat.api.parser.FetchGitlabProject')
+    def test_get_gitlab_project(self, mock_fetch):
+        mock_fetch.return_value = {'name': 'gitlab_project'}
+        url = "https://gitlab.com/user/project"
+        result = get_gitlab_project(url, False)
+        assert result == {'name': 'gitlab_project'}
+        mock_fetch.assert_called_once_with('user/project', False)
+
+        # Test with README path
+        url_readme = "https://gitlab.com/user/project/-/blob/main/README.md"
+        result = get_gitlab_project(url_readme, False)
+        assert result == {'name': 'gitlab_project'}
+        mock_fetch.assert_called_with('user/project', False)
+
+        # Empty
+        assert get_gitlab_project("https://gitlab.com/", False) == {}
+
+    @patch('dribdat.api.parser.FetchGithubProject')
+    @patch('dribdat.api.parser.FetchWebGitHubGist')
+    @patch('dribdat.api.parser.FetchWebGitHub')
+    @patch('dribdat.api.parser.FetchGithubIssue')
+    def test_get_github_project(self, mock_issue, mock_web, mock_gist, mock_project):
+        # Regular project
+        mock_project.return_value = {'name': 'gh_project'}
+        url = "https://github.com/user/project"
+        assert get_github_project(url, False) == {'name': 'gh_project'}
+        mock_project.assert_called_once_with('user/project', False)
+
+        # Gist
+        mock_gist.return_value = {'name': 'gist'}
+        url_gist = "https://gist.github.com/user/gistid"
+        assert get_github_project(url_gist, False) == {'name': 'gist'}
+        mock_gist.assert_called_once_with(url_gist)
+
+        # Markdown (not README)
+        mock_web.return_value = {'name': 'web_gh'}
+        url_md = "https://github.com/user/project/blob/main/docs/guide.md"
+        assert get_github_project(url_md, False) == {'name': 'web_gh'}
+        mock_web.assert_called_once_with(url_md)
+
+        # Issue
+        mock_issue.return_value = {'name': 'issue'}
+        url_issue = "https://github.com/user/project/issues/123"
+        assert get_github_project(url_issue, False) == {'name': 'issue'}
+        mock_issue.assert_called_once_with('user/project', 123)
+
+        # Empty
+        assert get_github_project("https://github.com/", False) == {}
+
+        # .git suffix
+        mock_project.return_value = {'name': 'gh_project_git'}
+        assert get_github_project("https://github.com/user/project.git", False) == {'name': 'gh_project_git'}
+
+    @patch('dribdat.api.parser.FetchCodebergProject')
+    def test_get_codeberg_project(self, mock_fetch):
+        mock_fetch.return_value = {'name': 'cb_project'}
+        url = "https://codeberg.org/user/project"
+        assert get_codeberg_project(url, False) == {'name': 'cb_project'}
+        mock_fetch.assert_called_once_with('user/project', False)
+
+        # .git suffix
+        assert get_codeberg_project("https://codeberg.org/user/project.git", False) == {'name': 'cb_project'}
+
+        # Empty
+        assert get_codeberg_project("https://codeberg.org/", False) == {}
+
+    @patch('dribdat.api.parser.FetchHuggingFaceProject')
+    def test_get_huggingface_project(self, mock_fetch):
+        mock_fetch.return_value = {'name': 'hf_project'}
+        url = "https://huggingface.co/user/project"
+        assert get_huggingface_project(url, False) == {'name': 'hf_project'}
+        mock_fetch.assert_called_once_with('user/project', False)
+
+        # Empty
+        assert get_huggingface_project("https://huggingface.co/", False) == {}
+
+    @patch('dribdat.api.parser.get_gitlab_project')
+    @patch('dribdat.api.parser.get_huggingface_project')
+    @patch('dribdat.api.parser.get_github_project')
+    @patch('dribdat.api.parser.get_codeberg_project')
+    @patch('dribdat.api.parser.FetchGitProject')
+    @patch('dribdat.api.parser.FetchDataProject')
+    @patch('dribdat.api.parser.FetchDribdatProject')
+    @patch('dribdat.api.parser.FetchWebProject')
+    def test_get_project_data(self, mock_web, mock_dribdat, mock_data, mock_git, mock_cb, mock_gh, mock_hf, mock_gl):
+        # GitLab
+        GetProjectData("https://gitlab.com/u/p")
+        mock_gl.assert_called_once()
+
+        # HF
+        GetProjectData("https://huggingface.co/u/p")
+        mock_hf.assert_called_once()
+
+        # GitHub
+        GetProjectData("https://github.com/u/p")
+        mock_gh.assert_called_once()
+
+        # Codeberg
+        GetProjectData("https://codeberg.org/u/p")
+        mock_cb.assert_called_once()
+
+        # .git
+        GetProjectData("https://example.com/repo.git")
+        mock_git.assert_called_once()
+
+        # .json
+        GetProjectData("https://example.com/data.json")
+        mock_data.assert_called_once()
+
+        # Dribdat project
+        mock_dribdat.return_value = {'name': 'dribdat'}
+        GetProjectData("https://dribdat.example.com/project/1")
+        mock_dribdat.assert_called_once()
+
+        # Generic web
+        GetProjectData("https://example.com/page")
+        mock_web.assert_called_once()

--- a/tests/test_auth_more.py
+++ b/tests/test_auth_more.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+import pytest
+from flask import url_for, current_app
+from dribdat.user.models import User, Event
+from .factories import UserFactory, ProjectFactory, EventFactory
+from unittest.mock import patch
+
+@pytest.mark.usefixtures('db')
+class TestAuthEdgeCases:
+
+    def test_enter_forgot(self, testapp):
+        """Test the enter route redirection."""
+        testapp.app.config['MAIL_SERVER'] = 'localhost'
+        testapp.app.config['OAUTH_TYPE'] = None
+        res = testapp.get('/enter/')
+        assert res.status_code == 302
+        assert res.location.endswith('/forgot/')
+
+    def test_enter_login(self, testapp):
+        """Test the enter route redirection when no mail server."""
+        testapp.app.config['MAIL_SERVER'] = None
+        res = testapp.get('/enter/')
+        assert res.status_code == 302
+        assert res.location.endswith('/login/')
+
+    def test_login_skip_oauth(self, testapp):
+        """Test skipping login when OAUTH_SKIP_LOGIN is set."""
+        testapp.app.config['OAUTH_SKIP_LOGIN'] = True
+        testapp.app.config['OAUTH_TYPE'] = 'github'
+        # Mock url_for to avoid build error during test
+        with patch('dribdat.public.auth.url_for') as mock_url_for:
+            mock_url_for.return_value = '/github_login'
+            res = testapp.get('/login/')
+            assert res.status_code == 302
+            assert '/github_login' in res.location
+
+    def test_register_disabled(self, testapp):
+        """Test registration when disabled."""
+        testapp.app.config['DRIBDAT_NOT_REGISTER'] = True
+        res = testapp.get('/register/')
+        assert res.status_code == 302
+        assert 'Registration currently not possible' in res.follow().text
+
+    def test_delete_account(self, testapp, user):
+        """Test deleting a user account."""
+        # Create a project owned by user
+        project = ProjectFactory(user=user)
+        project.save()
+
+        # Login
+        res = testapp.get('/login/')
+        form = res.forms['loginForm']
+        form['username'] = user.username
+        form['password'] = 'myprecious'
+        res = form.submit().follow()
+
+        # Delete account
+        res = testapp.post('/user/profile/delete')
+        assert res.status_code == 302
+        assert User.query.filter_by(id=user.id).first() is None
+        assert project.user_id is None
+
+    def test_user_profile_edit_sso(self, testapp, user):
+        """Test editing profile for SSO user."""
+        user.sso_id = 'sso123'
+        user.save()
+
+        # Login
+        res = testapp.get('/login/')
+        form = res.forms['loginForm']
+        form['username'] = user.username
+        form['password'] = 'myprecious'
+        res = form.submit().follow()
+
+        res = testapp.get('/user/profile')
+        # The form on this page doesn't have an id, find it by index
+        form = res.forms[0]
+        assert 'password' not in form.fields
+
+    def test_user_profile_email_conflict(self, testapp, user):
+        """Test editing profile with conflicting email."""
+        other_user = UserFactory(email='other@example.com')
+        other_user.save()
+
+        # Login
+        res = testapp.get('/login/')
+        form = res.forms['loginForm']
+        form['username'] = user.username
+        form['password'] = 'myprecious'
+        res = form.submit().follow()
+
+        res = testapp.get('/user/profile')
+        form = res.forms[0]
+        form['email'] = 'other@example.com'
+        res = form.submit()
+        assert 'This e-mail address is already registered.' in res.text
+
+    def test_passwordless_no_mail(self, testapp):
+        """Test passwordless login when mail server is not configured."""
+        testapp.app.config['MAIL_SERVER'] = None
+        res = testapp.post('/passwordless/')
+        assert res.status_code == 302
+        assert 'login' in res.location
+
+    def test_passwordless_success(self, testapp, user):
+        """Test passwordless login request."""
+        testapp.app.config['MAIL_SERVER'] = 'localhost'
+        res = testapp.post('/passwordless/', {'username': user.email})
+        assert res.status_code == 302
+        assert 'activation mail' in res.follow().text
+
+    def test_user_ranking_no_event(self, testapp, user):
+        """Test user ranking when no current event."""
+        Event.query.update({Event.is_current: False})
+
+        # Login
+        res = testapp.get('/login/')
+        form = res.forms['loginForm']
+        form['username'] = user.username
+        form['password'] = 'myprecious'
+        res = form.submit().follow()
+
+        res = testapp.get('/user/ranking')
+        assert res.status_code == 302
+        assert 'no current event' in res.follow().text

--- a/tests/test_project_more.py
+++ b/tests/test_project_more.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+import pytest
+from flask import url_for
+from dribdat.user.models import Project, Activity
+from .factories import UserFactory, ProjectFactory, EventFactory
+from dribdat.aggregation import ProjectActivity
+
+@pytest.mark.usefixtures('db')
+class TestProjectActions:
+
+    def test_project_star_me(self, testapp, user):
+        """Test starring a project."""
+        event = EventFactory()
+        project = ProjectFactory(event=event)
+        project.save()
+
+        # Login
+        res = testapp.get('/login/')
+        form = res.forms['loginForm']
+        form['username'] = user.username
+        form['password'] = 'myprecious'
+        res = form.submit().follow()
+
+        # Star project
+        res = testapp.get(f'/project/{project.id}/star/me').follow()
+        assert res.status_code == 200
+        assert project.name in res.text
+        # Verify activity
+        assert Activity.query.filter_by(name='star', project_id=project.id, user_id=user.id).count() == 1
+
+    def test_project_unstar_me(self, testapp, user):
+        """Test unstarring a project."""
+        event = EventFactory()
+        project = ProjectFactory(event=event)
+        project.save()
+        ProjectActivity(project, 'star', user)
+
+        # Login
+        res = testapp.get('/login/')
+        form = res.forms['loginForm']
+        form['username'] = user.username
+        form['password'] = 'myprecious'
+        res = form.submit().follow()
+
+        # Unstar project
+        res = testapp.get(f'/project/{project.id}/unstar/me').follow()
+        assert res.status_code == 200
+        # Verify activity is gone
+        assert Activity.query.filter_by(name='star', project_id=project.id, user_id=user.id).count() == 0
+
+    def test_project_autoupdate(self, testapp, user):
+        """Test autoupdating a project."""
+        event = EventFactory()
+        project = ProjectFactory(autotext_url='https://github.com/user/repo', event=event)
+        project.user = user
+        project.save()
+
+        # Login
+        res = testapp.get('/login/')
+        form = res.forms['loginForm']
+        form['username'] = user.username
+        form['password'] = 'myprecious'
+        res = form.submit().follow()
+
+        from unittest.mock import patch
+        with patch('dribdat.public.project.GetProjectData') as mock_data, \
+             patch('dribdat.public.project.SyncProjectData') as mock_sync:
+            mock_data.return_value = {'name': 'Updated Name', 'type': 'github', 'autotext': 'Content'}
+            res = testapp.get(f'/project/{project.id}/autoupdate').follow()
+            assert res.status_code == 200
+            mock_sync.assert_called_once()
+
+    def test_project_log(self, testapp):
+        """Test project log view."""
+        event = EventFactory()
+        project = ProjectFactory(event=event)
+        project.save()
+        res = testapp.get(f'/project/{project.id}/log')
+        assert res.status_code == 200
+
+    def test_project_toggle(self, testapp, user):
+        """Test toggling project status (hidden/visible)."""
+        # Set user as admin to bypass AllowProjectEdit restrictions on hidden projects
+        user.is_admin = True
+        user.save()
+
+        event = EventFactory()
+        project = ProjectFactory(is_hidden=False, event=event)
+        project.user = user
+        project.save()
+        pid = project.id
+
+        # Login
+        res = testapp.get('/login/')
+        form = res.forms['loginForm']
+        form['username'] = user.username
+        form['password'] = 'myprecious'
+        res = form.submit().follow()
+
+        # Toggle (becomes hidden)
+        res = testapp.get(f'/project/{pid}/toggle')
+        assert res.status_code == 302
+        assert Project.query.get(pid).is_hidden == True
+
+    def test_project_post(self, testapp, user):
+        """Test posting to a project."""
+        event = EventFactory()
+        project = ProjectFactory(event=event)
+        project.user = user
+        project.save()
+
+        # Login
+        res = testapp.get('/login/')
+        form = res.forms['loginForm']
+        form['username'] = user.username
+        form['password'] = 'myprecious'
+        res = form.submit().follow()
+
+        res = testapp.get(f'/project/{project.id}/post')
+        form = res.forms[0]
+        form['note'] = 'Test post content'
+        res = form.submit().follow()
+        assert 'Test post content' in res.text
+
+    def test_project_comment(self, testapp, user):
+        """Test commenting on a project."""
+        event = EventFactory()
+        project = ProjectFactory(event=event)
+        project.save()
+
+        # Login
+        res = testapp.get('/login/')
+        form = res.forms['loginForm']
+        form['username'] = user.username
+        form['password'] = 'myprecious'
+        res = form.submit().follow()
+
+        res = testapp.get(f'/project/{project.id}/comment')
+        form = res.forms[0]
+        form['note'] = 'Test comment content'
+        res = form.submit().follow()
+        assert 'feedback' in res.text


### PR DESCRIPTION
This PR increases the test coverage for several key modules in the dribdat application: `dribdat/api/parser.py`, `dribdat/public/auth.py`, and `dribdat/public/project.py`. 

Key changes include:
- New test files that exercise various edge cases and paths in the mentioned modules.
- Unit tests with mocking for external API calls in the parser.
- Integration tests using the `testapp` fixture for web routes.
- Minor defensive programming improvements in `parser.py` and `auth.py` to handle empty or invalid configuration/URLs more gracefully.

All tests passed locally with significantly improved coverage.

---
*PR created automatically by Jules for task [18090239762187439400](https://jules.google.com/task/18090239762187439400) started by @loleg*