### PR TITLE
Fix 34-minute delay in timestamps

### DIFF
--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -664,12 +664,16 @@ class Event(PkModel):
     @property
     def ends_at_tz(self):
         """Extra property."""
-        return self.ends_at.replace(tzinfo=current_app.tz)  # pyright: ignore
+        if self.ends_at.tzinfo:
+            return self.ends_at.astimezone(current_app.tz)
+        return self.ends_at.replace(tzinfo=UTC).astimezone(current_app.tz)
 
     @property
     def starts_at_tz(self):
         """Extra property."""
-        return self.starts_at.replace(tzinfo=current_app.tz)  # pyright: ignore
+        if self.starts_at.tzinfo:
+            return self.starts_at.astimezone(current_app.tz)
+        return self.starts_at.replace(tzinfo=UTC).astimezone(current_app.tz)
 
     @property
     def countdown(self):
@@ -1455,7 +1459,10 @@ class Activity(PkModel):
     @property
     def data(self):
         """Get JSON representation."""
-        localtime = self.timestamp.replace(tzinfo=current_app.tz)  # pyright: ignore
+        if self.timestamp.tzinfo:
+            localtime = self.timestamp.astimezone(current_app.tz)
+        else:
+            localtime = self.timestamp.replace(tzinfo=UTC).astimezone(current_app.tz)
         a = {
             "id": self.id,
             "time": int(mktime(self.timestamp.timetuple())),

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -42,7 +42,7 @@ class TestEvent:
         assert event.starts_at != event_dt  # store as naive!?
         assert event.name == "test"
         assert event.countdown is not None
-        assert event.countdown == event_dt.replace(tzinfo=timezone)
+        assert event.countdown == event_dt.astimezone(timezone)
         assert timesince(event.countdown, until=True) == "1 week"
 
     def test_countdown_24_days(self):
@@ -55,7 +55,7 @@ class TestEvent:
         assert event.starts_at != event_dt  # store as naive!?
         assert event.name == "test"
         assert event.countdown is not None
-        assert event.countdown == event_dt.replace(tzinfo=timezone)
+        assert event.countdown == event_dt.astimezone(timezone)
         assert timesince(event.countdown, until=True) == "3 weeks"
 
     def test_countdown_4_hours(self):


### PR DESCRIPTION
I fixed the infamous 34-minute delay in Dribdat timestamps. The issue was caused by an incorrect use of `pytz` timezones in the Python code. Specifically, when using `.replace(tzinfo=...)` with a Zurich timezone on a naive datetime, it would apply the historical "Local Mean Time" offset (+34 minutes) instead of the modern UTC+1/+2 offset. I updated the `Activity` and `Event` models to correctly interpret naive timestamps from the database as UTC before converting them to the user's local timezone. I also updated the test suite to verify this fix and ensure no regressions.

---
*PR created automatically by Jules for task [804198298322481602](https://jules.google.com/task/804198298322481602) started by @loleg*