### PR TITLE
Expand admin notifications and consolidate mailer logic

### DIFF
--- a/dribdat/mailer.py
+++ b/dribdat/mailer.py
@@ -14,6 +14,17 @@ You can delete your account any time by editing your profile.
 """
 
 
+def send_mail(msg, log_message=None):
+    """Send an e-mail message."""
+    if "mailman" not in current_app.extensions:
+        current_app.logger.warning("E-mail extension has not been configured")
+        return False
+    if log_message:
+        current_app.logger.info(log_message)
+    msg.send(fail_silently=True)
+    return True
+
+
 def user_activation_message(user, act_hash):
     """Prepare a message to send to the user."""
     # base_url = url_for("public.home", _external=True)
@@ -46,25 +57,16 @@ def user_activation(user):
     user.set_hashword(act_hash)
     user.save()
     msg = user_activation_message(user, act_hash)
-    # print(msg.body)
-    if "mailman" not in current_app.extensions:
-        current_app.logger.warning("E-mail extension has not been configured")
-        return act_hash
     msg.to = [user.email]
-    current_app.logger.info("Sending activation mail to user %d" % user.id)
-    msg.send(fail_silently=True)
+    send_mail(msg, "Sending activation mail to user %d" % user.id)
     return act_hash
 
 
 def user_registration(user_email):
     """Send an invitation by e-mail."""
     msg = user_invitation_message()
-    if "mailman" not in current_app.extensions:
-        current_app.logger.warning("E-mail extension has not been configured")
-        return
     msg.to = [user_email]
-    current_app.logger.info("Sending registration mail")
-    msg.send(fail_silently=True)
+    send_mail(msg, "Sending registration mail")
 
 
 def user_assignment_message(user, project, comment=""):
@@ -87,11 +89,7 @@ were matched with a potential project team:
     body += "Tap the JOIN button if you agree!\n"
     body += EMAIL_SIGNATURE
     msg.body = body
-    if "mailman" not in current_app.extensions:
-        current_app.logger.warning("E-mail extension has not been configured")
-        return
-    current_app.logger.info("Sending assignment mail to user %d" % user.id)
-    msg.send(fail_silently=True)
+    send_mail(msg, "Sending assignment mail to user %d" % user.id)
 
 
 def user_invitation_message(project=None):
@@ -121,14 +119,9 @@ def user_invitation_message(project=None):
 
 def user_invitation(user_email, project):
     """Send an invitation by e-mail."""
-    if "mailman" not in current_app.extensions:
-        current_app.logger.warning("E-mail extension has not been configured")
-        return False
     msg = user_invitation_message(project)
     msg.to = [user_email]
-    current_app.logger.info("Sending activation mail to %s" % user_email)
-    msg.send(fail_silently=True)
-    return True
+    return send_mail(msg, "Sending activation mail to %s" % user_email)
 
 
 def notify_admin_message(about=""):
@@ -148,12 +141,8 @@ def notify_admin(about=""):
     if current_app.config["MAIL_NOTIFY_ADMIN"] is None:
         # No e-mail address configured
         return False
-    if "mailman" not in current_app.extensions:
-        return False
     if "@" not in current_app.config["MAIL_NOTIFY_ADMIN"]:
         current_app.logger.warn("MAIL_NOTIFY_ADMIN must contain an e-mail address")
         return False
-    current_app.logger.info("Sending admin a notification mail")
     msg = notify_admin_message(about)
-    msg.send(fail_silently=True)
-    return True
+    return send_mail(msg, "Sending admin a notification mail")

--- a/dribdat/public/project.py
+++ b/dribdat/public/project.py
@@ -38,6 +38,7 @@ from dribdat.user import (
     stageProjectToNext,
     isUserActive,
 )
+from dribdat.mailer import notify_admin
 from dribdat.public.projhelper import (
     project_action,
     project_edit_action,
@@ -688,6 +689,8 @@ def import_new_project(event_id):
 
     project_action(project.id, "create", False)
     if not current_user.is_admin:
+        notify_admin("A new project '%s' has been imported to '%s' by %s" %
+                     (project.name, event.name, current_user.username))
         flash("Invite others to Join this challenge, and contribute", "success")
         # Join the project as first member
         project_action(project.id, "star", then_redirect=False, for_user=current_user)
@@ -784,12 +787,17 @@ def create_new_project(event):
     if is_anonymous:
         flash("Thanks for your submission - Join in to make changes.", "success")
     elif event.lock_resources:
+        if not current_user.is_admin:
+            notify_admin("A new bootstrap '%s' has been created in '%s' by %s" %
+                         (project.name, event.name, current_user.username))
         flash("Thanks for sharing a bootstrap here", "success")
     else:
         flash("You can now invite others to Join this page and contribute", "success")
         project_action(project.id, "create", False)
         # Automatically join new projects
         if not current_user.is_admin:
+            notify_admin("A new project '%s' has been created in '%s' by %s" %
+                         (project.name, event.name, current_user.username))
             project_action(project.id, "star", False)
 
     # Continue to project view

--- a/dribdat/public/views.py
+++ b/dribdat/public/views.py
@@ -26,6 +26,7 @@ from dribdat.public.userhelper import (
 from dribdat.public.forms import EventNew, EventEdit
 from dribdat.public.projhelper import current_event
 from dribdat.database import db
+from dribdat.mailer import notify_admin
 from dribdat.extensions import cache
 from dribdat.aggregation import GetEventUsers
 from urllib.parse import urlparse
@@ -563,6 +564,8 @@ def event_new():
             if not current_user.is_admin:
                 event.is_hidden = True
                 event.save()
+                notify_admin("A new event '%s' has been created by %s" %
+                             (event.name, current_user.username))
                 flash(
                     "Please contact an administrator (see About page)"
                     + "to make changes or to promote this event.",

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""Functional tests for admin notifications."""
+from flask import url_for
+from dribdat.user.models import Event, Project
+
+class TestAdminNotifications:
+    """Admin notifications."""
+
+    def test_notify_admin_on_event_creation(self, user, testapp):
+        """Test that admin is notified when a new event is created."""
+        user.is_admin = False
+        user.set_password('password')
+        user.save()
+
+        # Login
+        res = testapp.get('/login/')
+        form = res.forms['loginForm']
+        form['username'] = user.username
+        form['password'] = 'password'
+        res = form.submit().follow()
+
+        # Enable events in config for testing
+        testapp.app.config['DRIBDAT_ALLOW_EVENTS'] = True
+        testapp.app.config['MAIL_NOTIFY_ADMIN'] = 'admin@example.com'
+        testapp.app.config['MAIL_SERVER'] = 'localhost' # Needed to initialize mailman
+        testapp.app.testing = True
+
+        # Initialize mailman manually for testing since it wasn't initialized in TestConfig
+        from flask_mailman import Mail
+        mail = Mail()
+        mail.init_app(testapp.app)
+
+        # Ensure we use locmem backend and clear outbox
+        testapp.app.extensions['mailman'].outbox = []
+
+        # Go to new event page
+        res = testapp.get(url_for('public.event_new'))
+        form = res.forms[0]
+        form['name'] = 'New Shiny Event'
+
+        res = form.submit().follow()
+        assert res.status_code == 200
+        assert Event.query.filter_by(name='New Shiny Event').first() is not None
+
+        # Check if notification was sent
+        outbox = testapp.app.extensions['mailman'].outbox
+        assert len(outbox) > 0
+        assert any('A new event' in m.body for m in outbox)
+        assert any('admin@example.com' in m.to for m in outbox)
+
+    def test_notify_admin_on_project_creation(self, user, testapp):
+        """Test that admin is notified when a new project is created."""
+        user.is_admin = False
+        user.set_password('password')
+        user.save()
+
+        # Create an event
+        from .factories import EventFactory
+        event = EventFactory()
+        event.lock_resources = False # Not a bootstrap event
+        event.save()
+
+        # Login
+        res = testapp.get('/login/')
+        form = res.forms['loginForm']
+        form['username'] = user.username
+        form['password'] = 'password'
+        res = form.submit().follow()
+
+        testapp.app.config['MAIL_NOTIFY_ADMIN'] = 'admin@example.com'
+        testapp.app.config['MAIL_SERVER'] = 'localhost' # Needed to initialize mailman
+        testapp.app.testing = True
+
+        # Initialize mailman manually for testing since it wasn't initialized in TestConfig
+        from flask_mailman import Mail
+        mail = Mail()
+        mail.init_app(testapp.app)
+
+        # Ensure we use locmem backend and clear outbox
+        testapp.app.extensions['mailman'].outbox = []
+
+        # Go to new project page
+        res = testapp.get(url_for('project.project_new', event_id=event.id))
+        form = res.forms['projectNew']
+        form['name'] = 'New Shiny Project'
+
+        res = form.submit().follow()
+        assert res.status_code == 200
+        assert Project.query.filter_by(name='New Shiny Project').first() is not None
+
+        # Check if notification was sent
+        outbox = testapp.app.extensions['mailman'].outbox
+        assert len(outbox) > 0
+        assert any('A new project' in m.body for m in outbox)
+        assert any('admin@example.com' in m.to for m in outbox)


### PR DESCRIPTION
This PR expands the use of `MAIL_NOTIFY_ADMIN` to alert administrators when new events or projects (challenges) are created by users. It also refactors the `dribdat/mailer.py` module to use a consolidated `send_mail` helper, improving maintainability and reducing code duplication. Functional tests have been added to ensure that notifications are correctly triggered and dispatched.

---
*PR created automatically by Jules for task [8996307560994276911](https://jules.google.com/task/8996307560994276911) started by @loleg*